### PR TITLE
MacOS support

### DIFF
--- a/src/vagrant.rb
+++ b/src/vagrant.rb
@@ -599,7 +599,7 @@ class VagrantChefPolicyfileProvisioner < VagrantProvisioner
       machine.vagrant.trigger.before trigger_actions do |trigger|
         trigger.name = "#{name}_zip"
         trigger.run = {
-          inline: "rm #{host_file_path}; 7z a -sdel #{host_file_path} #{host_directory_path}",
+          inline: "7z a -sdel #{host_file_path} #{host_directory_path}",
         }
       end
 

--- a/src/vagrant.rb
+++ b/src/vagrant.rb
@@ -579,14 +579,15 @@ class VagrantChefPolicyfileProvisioner < VagrantProvisioner
 
       trigger_actions = (File.exist?(host_file_path) && File.size(host_file_path) > 0) ? [:provision] : [:up, :provision]
 
-      FileUtils.mkdir_p File.dirname(host_file_path)
-      FileUtils.touch host_file_path
-
       machine.vagrant.trigger.before trigger_actions do |trigger|
         trigger.name = "#{name}_chef_install"
         trigger.run = {
           inline: "chef install #{policyfile_path}",
         }
+        trigger.ruby do
+          FileUtils.mkdir_p File.dirname(host_file_path)
+          FileUtils.rm_f host_file_path
+        end
       end
 
       machine.vagrant.trigger.before trigger_actions do |trigger|


### PR DESCRIPTION
## Context

I have a local branch ready to add support for building Windows VMs in MacOS in gusztavvargadr/packer. This PR must come first.

## Commits

### Fix: Local run triggers on MacOS.

Local run triggers should be binaries, not scripts. This fails in MacOS.

See https://www.vagrantup.com/docs/triggers/configuration#run

### Fix: Immutable local file modifications.

These lines were being called multiple times, which is unnecessary.